### PR TITLE
Prepare 0.11.0-beta.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.0-beta.1] - 2019-12-24
+
 ## [0.10.2] - 2019-12-09
 ### Added
 - Add `UnregisterDevice` call to Pairing protocol.

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Astarte.RPC.Mixfile do
   def project do
     [
       app: :astarte_rpc,
-      version: "0.11.0-dev",
+      version: "0.11.0-beta.1",
       elixir: "~> 1.8",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Update CHANGELOG.md with 0.11.0-beta.1 release date and bump mix.exs
version.

Signed-off-by: Davide Bettio <davide.bettio@ispirata.com>