### PR TITLE
CI: update elixir and otp version

### DIFF
--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -12,8 +12,8 @@ on:
   pull_request:
 
 env:
-  elixir_version: 1.8.1
-  otp_version: 21.3
+  elixir_version: 1.10.1
+  otp_version: 22.2
 
 jobs:
   test-dialyzer:


### PR DESCRIPTION
Update elixir and otp version to 1.10.1 and 22.2 respectively
