### PR TITLE
Default max certificate chain length to 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Change env variable ASTARTE_RPC_AMQP_PREFETCH_COUNT into RPC_AMQP_PREFETCH_COUNT
 - Change env variable ASTARTE_RPC_AMQP_QUEUE_MAX_LENGTH into RPC_AMQP_QUEUE_MAX_LENGTH
 
+### Added
+- Support SSL connections to RabbitMQ.
+- Default max certificate chain length to 10.
+
 ## [0.11.0-rc.0] - 2020-02-26
 ### Fixed
 - Make .proto files fully compliant with Protocol Buffers Version 3.

--- a/lib/astarte_rpc/config.ex
+++ b/lib/astarte_rpc/config.ex
@@ -114,6 +114,7 @@ defmodule Astarte.RPC.Config do
           {:cacertfile, String.t()}
           | {:verify, :verify_peer}
           | {:server_name_indication, :disable | charlist()}
+          | {:depth, integer()}
   @type ssl_options :: :none | [ssl_option]
 
   @type options ::
@@ -154,7 +155,8 @@ defmodule Astarte.RPC.Config do
   defp build_ssl_options() do
     [
       cacertfile: amqp_connection_ssl_ca_file!() || CAStore.file_path(),
-      verify: :verify_peer
+      verify: :verify_peer,
+      depth: 10
     ]
     |> populate_sni()
   end


### PR DESCRIPTION
The erlang default of 1 is too strict. Increase the default value to 10
to make it coincident to OpenSSL default.