### PR TITLE
Update RabbitMQ to 3.8.12

### DIFF
--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         rabbitmq:
-        - "rabbitmq:3.7.21-management"
+        - "rabbitmq:3.8.12-management"
     services:
       rabbitmq:
         image: ${{ matrix.rabbitmq }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.0-beta.2] - Unreleased
 ### Changed
 - Update dependencies and Elixir version to 1.11
+- Test against RabbitMQ 3.8.12
 
 ## [1.0.0-beta.1] - 2021-02-11
 


### PR DESCRIPTION
Use RabbitMQ 3.8.12-management docker image for CI purposes.