### PR TITLE
Add support for device deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Add support for device deletion.
+
 ## [1.1.0] - 2023-06-20
 
 ## [1.1.0-rc.0] - 2023-06-08

--- a/lib/astarte_rpc/protocol/proto/realm_management/call.pb.ex
+++ b/lib/astarte_rpc/protocol/proto/realm_management/call.pb.ex
@@ -93,4 +93,9 @@ defmodule Astarte.RPC.Protocol.RealmManagement.Call do
     type: Astarte.RPC.Protocol.RealmManagement.GetTriggerPolicySource,
     json_name: "getTriggerPolicySource",
     oneof: 0
+
+  field :delete_device, 19,
+    type: Astarte.RPC.Protocol.RealmManagement.DeleteDevice,
+    json_name: "deleteDevice",
+    oneof: 0
 end

--- a/lib/astarte_rpc/protocol/proto/realm_management/call.proto
+++ b/lib/astarte_rpc/protocol/proto/realm_management/call.proto
@@ -1,7 +1,7 @@
 //
 // This file is part of Astarte.
 //
-// Copyright 2017 Ispirata Srl
+// Copyright 2017 - 2023 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import "lib/astarte_rpc/protocol/proto/realm_management/install_trigger_policy.p
 import "lib/astarte_rpc/protocol/proto/realm_management/delete_trigger_policy.proto";
 import "lib/astarte_rpc/protocol/proto/realm_management/get_trigger_policies_list.proto";
 import "lib/astarte_rpc/protocol/proto/realm_management/get_trigger_policy_source.proto";
+import "lib/astarte_rpc/protocol/proto/realm_management/delete_device.proto";
 
 
 message Call {
@@ -58,5 +59,6 @@ message Call {
         DeleteTriggerPolicy delete_trigger_policy = 16;
         GetTriggerPoliciesList get_trigger_policies_list = 17;
         GetTriggerPolicySource get_trigger_policy_source = 18;
+        DeleteDevice delete_device = 19;
     }
 }

--- a/lib/astarte_rpc/protocol/proto/realm_management/delete_device.pb.ex
+++ b/lib/astarte_rpc/protocol/proto/realm_management/delete_device.pb.ex
@@ -1,0 +1,10 @@
+defmodule Astarte.RPC.Protocol.RealmManagement.DeleteDevice do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  def fully_qualified_name, do: "DeleteDevice"
+
+  field :realm_name, 1, proto3_optional: true, type: :string, json_name: "realmName"
+  field :device_id, 2, proto3_optional: true, type: :string, json_name: "deviceId"
+end

--- a/lib/astarte_rpc/protocol/proto/realm_management/delete_device.proto
+++ b/lib/astarte_rpc/protocol/proto/realm_management/delete_device.proto
@@ -1,0 +1,24 @@
+//
+// This file is part of Astarte.
+//
+// Copyright 2023 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+message DeleteDevice {
+    optional string realm_name = 1;
+    optional string device_id = 2;
+}

--- a/lib/astarte_rpc/protocol/proto/vmq_plugin/call.pb.ex
+++ b/lib/astarte_rpc/protocol/proto/vmq_plugin/call.pb.ex
@@ -10,4 +10,5 @@ defmodule Astarte.RPC.Protocol.VMQ.Plugin.Call do
   field :version, 1, type: :int32, deprecated: true
   field :disconnect, 3, type: Astarte.RPC.Protocol.VMQ.Plugin.Disconnect, oneof: 0
   field :publish, 2, type: Astarte.RPC.Protocol.VMQ.Plugin.Publish, oneof: 0
+  field :delete, 4, type: Astarte.RPC.Protocol.VMQ.Plugin.Delete, oneof: 0
 end

--- a/lib/astarte_rpc/protocol/proto/vmq_plugin/delete.pb.ex
+++ b/lib/astarte_rpc/protocol/proto/vmq_plugin/delete.pb.ex
@@ -1,0 +1,10 @@
+defmodule Astarte.RPC.Protocol.VMQ.Plugin.Delete do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  def fully_qualified_name, do: "Delete"
+
+  field :realm_name, 1, proto3_optional: true, type: :string, json_name: "realmName"
+  field :device_id, 2, proto3_optional: true, type: :string, json_name: "deviceId"
+end

--- a/lib/astarte_rpc/protocol/proto/vmq_plugin/delete.proto
+++ b/lib/astarte_rpc/protocol/proto/vmq_plugin/delete.proto
@@ -1,7 +1,7 @@
 //
 // This file is part of Astarte.
 //
-// Copyright 2017 - 2023 SECO Mind Srl
+// Copyright 2023 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,16 +18,7 @@
 
 syntax = "proto3";
 
-import "lib/astarte_rpc/protocol/proto/vmq_plugin/disconnect.proto";
-import "lib/astarte_rpc/protocol/proto/vmq_plugin/publish.proto";
-import "lib/astarte_rpc/protocol/proto/vmq_plugin/delete.proto";
-
-message Call {
-    int32 version = 1 [deprecated = true];
-
-    oneof call {
-        Disconnect disconnect = 3;
-        Publish publish = 2;
-        Delete delete = 4;
-    }
+message Delete {
+    optional string realm_name = 1;
+    optional string device_id = 2;
 }


### PR DESCRIPTION
Add the following:
- Realm Management RPC for handling the device deletion command;
- VMQ Plugin RPC for informing the broker that device deletion has been requested.