### PR TITLE
Handle device registration limit in HK and RM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add support to realm update.
 - Add `device_registration_limit` field to `CreateRealm`, `GetRealmReply`
   and `UpdateRealm`.
+- Add `GetDeviceRegistrationLimit[Reply]` to retrieve the maximum
+  number of registered devices per realm.
 
 ## [1.1.0] - 2023-06-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add support for device deletion.
 - Add support to realm update.
+- Add `device_registration_limit` field to `CreateRealm`, `GetRealmReply`
+  and `UpdateRealm`.
 
 ## [1.1.0] - 2023-06-20
 

--- a/lib/astarte_rpc/protocol/proto/housekeeping/create_realm.pb.ex
+++ b/lib/astarte_rpc/protocol/proto/housekeeping/create_realm.pb.ex
@@ -31,4 +31,9 @@ defmodule Astarte.RPC.Protocol.Housekeeping.CreateRealm do
     type: Astarte.RPC.Protocol.Housekeeping.CreateRealm.DatacenterReplicationFactorsEntry,
     json_name: "datacenterReplicationFactors",
     map: true
+
+  field :device_registration_limit, 7,
+    proto3_optional: true,
+    type: :int64,
+    json_name: "deviceRegistrationLimit"
 end

--- a/lib/astarte_rpc/protocol/proto/housekeeping/create_realm.proto
+++ b/lib/astarte_rpc/protocol/proto/housekeeping/create_realm.proto
@@ -1,7 +1,7 @@
 //
 // This file is part of Astarte.
 //
-// Copyright 2017 Ispirata Srl
+// Copyright 2017-2023 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,4 +27,5 @@ message CreateRealm {
     int32 replication_factor = 4;
     ReplicationClass replication_class = 5;
     map<string, int32> datacenter_replication_factors = 6;
+    optional int64 device_registration_limit = 7;
 }

--- a/lib/astarte_rpc/protocol/proto/housekeeping/get_realm_reply.pb.ex
+++ b/lib/astarte_rpc/protocol/proto/housekeeping/get_realm_reply.pb.ex
@@ -30,4 +30,9 @@ defmodule Astarte.RPC.Protocol.Housekeeping.GetRealmReply do
     type: Astarte.RPC.Protocol.Housekeeping.GetRealmReply.DatacenterReplicationFactorsEntry,
     json_name: "datacenterReplicationFactors",
     map: true
+
+  field :device_registration_limit, 6,
+    proto3_optional: true,
+    type: :int64,
+    json_name: "deviceRegistrationLimit"
 end

--- a/lib/astarte_rpc/protocol/proto/housekeeping/get_realm_reply.proto
+++ b/lib/astarte_rpc/protocol/proto/housekeeping/get_realm_reply.proto
@@ -1,7 +1,7 @@
 //
 // This file is part of Astarte.
 //
-// Copyright 2017 Ispirata Srl
+// Copyright 2017-2023 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,4 +26,5 @@ message GetRealmReply {
     int32 replication_factor = 3;
     ReplicationClass replication_class = 4;
     map<string, int32> datacenter_replication_factors = 5;
+    optional int64 device_registration_limit = 6;
 }

--- a/lib/astarte_rpc/protocol/proto/housekeeping/update_realm.pb.ex
+++ b/lib/astarte_rpc/protocol/proto/housekeeping/update_realm.pb.ex
@@ -1,9 +1,21 @@
+defmodule Astarte.RPC.Protocol.Housekeeping.RemoveLimit do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+end
+
+defmodule Astarte.RPC.Protocol.Housekeeping.SetLimit do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field :value, 1, type: :int64
+end
+
 defmodule Astarte.RPC.Protocol.Housekeeping.UpdateRealm.DatacenterReplicationFactorsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
-
-  def fully_qualified_name, do: "UpdateRealm.DatacenterReplicationFactorsEntry"
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   field :key, 1, type: :string
   field :value, 2, type: :int32
@@ -12,9 +24,9 @@ end
 defmodule Astarte.RPC.Protocol.Housekeeping.UpdateRealm do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
-  def fully_qualified_name, do: "UpdateRealm"
+  oneof :device_registration_limit, 0
 
   field :realm, 1, proto3_optional: true, type: :string
   field :jwt_public_key_pem, 3, proto3_optional: true, type: :string, json_name: "jwtPublicKeyPem"
@@ -26,7 +38,7 @@ defmodule Astarte.RPC.Protocol.Housekeeping.UpdateRealm do
 
   field :replication_class, 5,
     proto3_optional: true,
-    type: Astarte.RPC.Protocol.Housekeeping.ReplicationClass,
+    type: ReplicationClass,
     json_name: "replicationClass",
     enum: true
 
@@ -35,4 +47,14 @@ defmodule Astarte.RPC.Protocol.Housekeeping.UpdateRealm do
     type: Astarte.RPC.Protocol.Housekeeping.UpdateRealm.DatacenterReplicationFactorsEntry,
     json_name: "datacenterReplicationFactors",
     map: true
+
+  field :set_limit, 7,
+    type: Astarte.RPC.Protocol.Housekeeping.SetLimit,
+    json_name: "setLimit",
+    oneof: 0
+
+  field :remove_limit, 8,
+    type: Astarte.RPC.Protocol.Housekeeping.RemoveLimit,
+    json_name: "removeLimit",
+    oneof: 0
 end

--- a/lib/astarte_rpc/protocol/proto/housekeeping/update_realm.proto
+++ b/lib/astarte_rpc/protocol/proto/housekeeping/update_realm.proto
@@ -20,10 +20,20 @@ syntax = "proto3";
 
 import "lib/astarte_rpc/protocol/proto/housekeeping/replication_class.proto";
 
+message RemoveLimit {}
+
+message SetLimit {
+    int64 value = 1;
+}
+
 message UpdateRealm {
     optional string realm = 1;
     optional string jwt_public_key_pem = 3;
     optional int32 replication_factor = 4;
     optional ReplicationClass replication_class = 5;
     map<string, int32> datacenter_replication_factors = 6;
+    oneof device_registration_limit {
+        SetLimit set_limit = 7;
+        RemoveLimit remove_limit= 8;
+    }
 }

--- a/lib/astarte_rpc/protocol/proto/realm_management/call.pb.ex
+++ b/lib/astarte_rpc/protocol/proto/realm_management/call.pb.ex
@@ -98,4 +98,9 @@ defmodule Astarte.RPC.Protocol.RealmManagement.Call do
     type: Astarte.RPC.Protocol.RealmManagement.DeleteDevice,
     json_name: "deleteDevice",
     oneof: 0
+
+  field :get_device_registration_limit, 20,
+    type: Astarte.RPC.Protocol.RealmManagement.GetDeviceRegistrationLimit,
+    json_name: "getDeviceRegistrationLimit",
+    oneof: 0
 end

--- a/lib/astarte_rpc/protocol/proto/realm_management/call.proto
+++ b/lib/astarte_rpc/protocol/proto/realm_management/call.proto
@@ -36,6 +36,7 @@ import "lib/astarte_rpc/protocol/proto/realm_management/delete_trigger_policy.pr
 import "lib/astarte_rpc/protocol/proto/realm_management/get_trigger_policies_list.proto";
 import "lib/astarte_rpc/protocol/proto/realm_management/get_trigger_policy_source.proto";
 import "lib/astarte_rpc/protocol/proto/realm_management/delete_device.proto";
+import "lib/astarte_rpc/protocol/proto/realm_management/get_device_registration_limit.proto";
 
 
 message Call {
@@ -60,5 +61,6 @@ message Call {
         GetTriggerPoliciesList get_trigger_policies_list = 17;
         GetTriggerPolicySource get_trigger_policy_source = 18;
         DeleteDevice delete_device = 19;
+        GetDeviceRegistrationLimit get_device_registration_limit = 20;
     }
 }

--- a/lib/astarte_rpc/protocol/proto/realm_management/get_device_registration_limit.pb.ex
+++ b/lib/astarte_rpc/protocol/proto/realm_management/get_device_registration_limit.pb.ex
@@ -1,0 +1,9 @@
+defmodule Astarte.RPC.Protocol.RealmManagement.GetDeviceRegistrationLimit do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  def fully_qualified_name, do: "GetDeviceRegistrationLimit"
+
+  field :realm_name, 1, proto3_optional: true, type: :string, json_name: "realmName"
+end

--- a/lib/astarte_rpc/protocol/proto/realm_management/get_device_registration_limit.proto
+++ b/lib/astarte_rpc/protocol/proto/realm_management/get_device_registration_limit.proto
@@ -1,0 +1,23 @@
+//
+// This file is part of Astarte.
+//
+// Copyright 2023 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+message GetDeviceRegistrationLimit {
+    optional string realm_name = 1;
+}

--- a/lib/astarte_rpc/protocol/proto/realm_management/get_device_registration_limit_reply.pb.ex
+++ b/lib/astarte_rpc/protocol/proto/realm_management/get_device_registration_limit_reply.pb.ex
@@ -1,0 +1,12 @@
+defmodule Astarte.RPC.Protocol.RealmManagement.GetDeviceRegistrationLimitReply do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
+
+  def fully_qualified_name, do: "GetDeviceRegistrationLimitReply"
+
+  field :device_registration_limit, 1,
+    proto3_optional: true,
+    type: :int64,
+    json_name: "deviceRegistrationLimit"
+end

--- a/lib/astarte_rpc/protocol/proto/realm_management/get_device_registration_limit_reply.proto
+++ b/lib/astarte_rpc/protocol/proto/realm_management/get_device_registration_limit_reply.proto
@@ -1,0 +1,23 @@
+//
+// This file is part of Astarte.
+//
+// Copyright 2023 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+message GetDeviceRegistrationLimitReply {
+    optional int64 device_registration_limit = 1;
+}

--- a/lib/astarte_rpc/protocol/proto/realm_management/reply.pb.ex
+++ b/lib/astarte_rpc/protocol/proto/realm_management/reply.pb.ex
@@ -64,4 +64,9 @@ defmodule Astarte.RPC.Protocol.RealmManagement.Reply do
     type: Astarte.RPC.Protocol.RealmManagement.GetTriggerPolicySourceReply,
     json_name: "getTriggerPolicySourceReply",
     oneof: 0
+
+  field :get_device_registration_limit_reply, 14,
+    type: Astarte.RPC.Protocol.RealmManagement.GetDeviceRegistrationLimitReply,
+    json_name: "getDeviceRegistrationLimitReply",
+    oneof: 0
 end

--- a/lib/astarte_rpc/protocol/proto/realm_management/reply.proto
+++ b/lib/astarte_rpc/protocol/proto/realm_management/reply.proto
@@ -29,6 +29,7 @@ import "lib/astarte_rpc/protocol/proto/realm_management/get_triggers_list_reply.
 import "lib/astarte_rpc/protocol/proto/realm_management/get_health_reply.proto";
 import "lib/astarte_rpc/protocol/proto/realm_management/get_trigger_policies_list_reply.proto";
 import "lib/astarte_rpc/protocol/proto/realm_management/get_trigger_policy_source_reply.proto";
+import "lib/astarte_rpc/protocol/proto/realm_management/get_device_registration_limit_reply.proto";
 
 
 message Reply {
@@ -47,5 +48,6 @@ message Reply {
         GetHealthReply get_health_reply = 11;
         GetTriggerPoliciesListReply get_trigger_policies_list_reply = 12;
         GetTriggerPolicySourceReply get_trigger_policy_source_reply = 13;
+        GetDeviceRegistrationLimitReply get_device_registration_limit_reply = 14;
     }
 }


### PR DESCRIPTION
Allow to inspect the device registration limit among realm details in Housekeeping and to retrieve it in Realm Management.
See https://github.com/astarte-platform/astarte/pull/814 for further details.