### PR TITLE
Support max datastream TTL at Realm level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add support to realm update.
 - Add `device_registration_limit` field to `CreateRealm`, `GetRealmReply`
   and `UpdateRealm`.
+- Add `datastream_maximum_storage_retention` field to `CreateRealm`,
+  `GetRealmReply` and `UpdateRealm`.
 - Add `GetDeviceRegistrationLimit[Reply]` to retrieve the maximum
   number of registered devices per realm.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `GetRealmReply` and `UpdateRealm`.
 - Add `GetDeviceRegistrationLimit[Reply]` to retrieve the maximum
   number of registered devices per realm.
+- Add `GetDatastreamMaximumStorageRetention[Reply]` to retrieve the maximum
+  retention value for data in a realm.
 
 ### Changed
 - Bump Elixir to 1.15.7.

--- a/lib/astarte_rpc/protocol/proto/housekeeping/create_realm.pb.ex
+++ b/lib/astarte_rpc/protocol/proto/housekeeping/create_realm.pb.ex
@@ -1,9 +1,7 @@
 defmodule Astarte.RPC.Protocol.Housekeeping.CreateRealm.DatacenterReplicationFactorsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
-
-  def fully_qualified_name, do: "CreateRealm.DatacenterReplicationFactorsEntry"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field :key, 1, type: :string
   field :value, 2, type: :int32
@@ -12,9 +10,7 @@ end
 defmodule Astarte.RPC.Protocol.Housekeeping.CreateRealm do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
-
-  def fully_qualified_name, do: "CreateRealm"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field :realm, 1, proto3_optional: true, type: :string
   field :async_operation, 2, type: :bool, json_name: "asyncOperation"
@@ -36,4 +32,8 @@ defmodule Astarte.RPC.Protocol.Housekeeping.CreateRealm do
     proto3_optional: true,
     type: :int64,
     json_name: "deviceRegistrationLimit"
+
+  field :datastream_maximum_storage_retention, 8,
+    type: :int64,
+    json_name: "datastreamMaximumStorageRetention"
 end

--- a/lib/astarte_rpc/protocol/proto/housekeeping/create_realm.proto
+++ b/lib/astarte_rpc/protocol/proto/housekeeping/create_realm.proto
@@ -1,7 +1,7 @@
 //
 // This file is part of Astarte.
 //
-// Copyright 2017-2023 SECO Mind Srl
+// Copyright 2017-2024 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,4 +28,5 @@ message CreateRealm {
     ReplicationClass replication_class = 5;
     map<string, int32> datacenter_replication_factors = 6;
     optional int64 device_registration_limit = 7;
+    int64 datastream_maximum_storage_retention = 8;
 }

--- a/lib/astarte_rpc/protocol/proto/housekeeping/get_realm_reply.pb.ex
+++ b/lib/astarte_rpc/protocol/proto/housekeeping/get_realm_reply.pb.ex
@@ -1,9 +1,7 @@
 defmodule Astarte.RPC.Protocol.Housekeeping.GetRealmReply.DatacenterReplicationFactorsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
-
-  def fully_qualified_name, do: "GetRealmReply.DatacenterReplicationFactorsEntry"
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field :key, 1, type: :string
   field :value, 2, type: :int32
@@ -12,9 +10,7 @@ end
 defmodule Astarte.RPC.Protocol.Housekeeping.GetRealmReply do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto3
-
-  def fully_qualified_name, do: "GetRealmReply"
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field :realm_name, 1, proto3_optional: true, type: :string, json_name: "realmName"
   field :jwt_public_key_pem, 2, proto3_optional: true, type: :string, json_name: "jwtPublicKeyPem"
@@ -35,4 +31,8 @@ defmodule Astarte.RPC.Protocol.Housekeeping.GetRealmReply do
     proto3_optional: true,
     type: :int64,
     json_name: "deviceRegistrationLimit"
+
+  field :datastream_maximum_storage_retention, 7,
+    type: :int64,
+    json_name: "datastreamMaximumStorageRetention"
 end

--- a/lib/astarte_rpc/protocol/proto/housekeeping/get_realm_reply.proto
+++ b/lib/astarte_rpc/protocol/proto/housekeeping/get_realm_reply.proto
@@ -1,7 +1,7 @@
 //
 // This file is part of Astarte.
 //
-// Copyright 2017-2023 SECO Mind Srl
+// Copyright 2017-2024 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,4 +27,5 @@ message GetRealmReply {
     ReplicationClass replication_class = 4;
     map<string, int32> datacenter_replication_factors = 5;
     optional int64 device_registration_limit = 6;
+    int64 datastream_maximum_storage_retention = 7;
 }

--- a/lib/astarte_rpc/protocol/proto/housekeeping/update_realm.pb.ex
+++ b/lib/astarte_rpc/protocol/proto/housekeeping/update_realm.pb.ex
@@ -1,13 +1,13 @@
 defmodule Astarte.RPC.Protocol.Housekeeping.RemoveLimit do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 end
 
 defmodule Astarte.RPC.Protocol.Housekeeping.SetLimit do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field :value, 1, type: :int64
 end
@@ -15,7 +15,7 @@ end
 defmodule Astarte.RPC.Protocol.Housekeeping.UpdateRealm.DatacenterReplicationFactorsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   field :key, 1, type: :string
   field :value, 2, type: :int32
@@ -24,7 +24,7 @@ end
 defmodule Astarte.RPC.Protocol.Housekeeping.UpdateRealm do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
 
   oneof :device_registration_limit, 0
 
@@ -57,4 +57,9 @@ defmodule Astarte.RPC.Protocol.Housekeeping.UpdateRealm do
     type: Astarte.RPC.Protocol.Housekeeping.RemoveLimit,
     json_name: "removeLimit",
     oneof: 0
+
+  field :datastream_maximum_storage_retention, 9,
+    proto3_optional: true,
+    type: :int64,
+    json_name: "datastreamMaximumStorageRetention"
 end

--- a/lib/astarte_rpc/protocol/proto/housekeeping/update_realm.proto
+++ b/lib/astarte_rpc/protocol/proto/housekeeping/update_realm.proto
@@ -1,7 +1,7 @@
 //
 // This file is part of Astarte.
 //
-// Copyright 2023 SECO Mind Srl
+// Copyright 2023-2024 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,4 +36,5 @@ message UpdateRealm {
         SetLimit set_limit = 7;
         RemoveLimit remove_limit= 8;
     }
+    optional int64 datastream_maximum_storage_retention = 9;
 }

--- a/lib/astarte_rpc/protocol/proto/realm_management/call.pb.ex
+++ b/lib/astarte_rpc/protocol/proto/realm_management/call.pb.ex
@@ -103,4 +103,9 @@ defmodule Astarte.RPC.Protocol.RealmManagement.Call do
     type: Astarte.RPC.Protocol.RealmManagement.GetDeviceRegistrationLimit,
     json_name: "getDeviceRegistrationLimit",
     oneof: 0
+
+  field :get_datastream_maximum_storage_retention, 21,
+    type: Astarte.RPC.Protocol.RealmManagement.GetDatastreamMaximumStorageRetention,
+    json_name: "getDatastreamMaximumStorageRetention",
+    oneof: 0
 end

--- a/lib/astarte_rpc/protocol/proto/realm_management/call.proto
+++ b/lib/astarte_rpc/protocol/proto/realm_management/call.proto
@@ -1,7 +1,7 @@
 //
 // This file is part of Astarte.
 //
-// Copyright 2017 - 2023 SECO Mind Srl
+// Copyright 2017 - 2024 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import "lib/astarte_rpc/protocol/proto/realm_management/get_trigger_policies_lis
 import "lib/astarte_rpc/protocol/proto/realm_management/get_trigger_policy_source.proto";
 import "lib/astarte_rpc/protocol/proto/realm_management/delete_device.proto";
 import "lib/astarte_rpc/protocol/proto/realm_management/get_device_registration_limit.proto";
+import "lib/astarte_rpc/protocol/proto/realm_management/get_datastream_maximum_storage_retention.proto";
 
 
 message Call {
@@ -62,5 +63,6 @@ message Call {
         GetTriggerPolicySource get_trigger_policy_source = 18;
         DeleteDevice delete_device = 19;
         GetDeviceRegistrationLimit get_device_registration_limit = 20;
+        GetDatastreamMaximumStorageRetention get_datastream_maximum_storage_retention = 21;
     }
 }

--- a/lib/astarte_rpc/protocol/proto/realm_management/get_datastream_maximum_storage_retention.pb.ex
+++ b/lib/astarte_rpc/protocol/proto/realm_management/get_datastream_maximum_storage_retention.pb.ex
@@ -1,0 +1,7 @@
+defmodule Astarte.RPC.Protocol.RealmManagement.GetDatastreamMaximumStorageRetention do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  field :realm_name, 1, proto3_optional: true, type: :string, json_name: "realmName"
+end

--- a/lib/astarte_rpc/protocol/proto/realm_management/get_datastream_maximum_storage_retention.proto
+++ b/lib/astarte_rpc/protocol/proto/realm_management/get_datastream_maximum_storage_retention.proto
@@ -1,0 +1,23 @@
+//
+// This file is part of Astarte.
+//
+// Copyright 2024 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+message GetDatastreamMaximumStorageRetention {
+    optional string realm_name = 1;
+}

--- a/lib/astarte_rpc/protocol/proto/realm_management/get_datastream_maximum_storage_retention_reply.pb.ex
+++ b/lib/astarte_rpc/protocol/proto/realm_management/get_datastream_maximum_storage_retention_reply.pb.ex
@@ -1,0 +1,9 @@
+defmodule Astarte.RPC.Protocol.RealmManagement.GetDatastreamMaximumStorageRetentionReply do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.12.0"
+
+  field :datastream_maximum_storage_retention, 1,
+    type: :int64,
+    json_name: "datatreamMaximumStorageRetention"
+end

--- a/lib/astarte_rpc/protocol/proto/realm_management/get_datastream_maximum_storage_retention_reply.proto
+++ b/lib/astarte_rpc/protocol/proto/realm_management/get_datastream_maximum_storage_retention_reply.proto
@@ -1,0 +1,23 @@
+//
+// This file is part of Astarte.
+//
+// Copyright 2024 SECO Mind Srl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+message GetDatastreamMaximumStorageRetentionReply {
+    int64 datastream_maximum_storage_retention = 1;
+}

--- a/lib/astarte_rpc/protocol/proto/realm_management/reply.pb.ex
+++ b/lib/astarte_rpc/protocol/proto/realm_management/reply.pb.ex
@@ -69,4 +69,9 @@ defmodule Astarte.RPC.Protocol.RealmManagement.Reply do
     type: Astarte.RPC.Protocol.RealmManagement.GetDeviceRegistrationLimitReply,
     json_name: "getDeviceRegistrationLimitReply",
     oneof: 0
+
+  field :get_datastream_maximum_storage_retention_reply, 15,
+    type: Astarte.RPC.Protocol.RealmManagement.GetDatastreamMaximumStorageRetentionReply,
+    json_name: "getDatastreamMaximumStorageRetentionReply",
+    oneof: 0
 end

--- a/lib/astarte_rpc/protocol/proto/realm_management/reply.proto
+++ b/lib/astarte_rpc/protocol/proto/realm_management/reply.proto
@@ -1,7 +1,7 @@
 //
 // This file is part of Astarte.
 //
-// Copyright 2017 Ispirata Srl
+// Copyright 2017-2024 SECO Mind Srl
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import "lib/astarte_rpc/protocol/proto/realm_management/get_health_reply.proto";
 import "lib/astarte_rpc/protocol/proto/realm_management/get_trigger_policies_list_reply.proto";
 import "lib/astarte_rpc/protocol/proto/realm_management/get_trigger_policy_source_reply.proto";
 import "lib/astarte_rpc/protocol/proto/realm_management/get_device_registration_limit_reply.proto";
+import "lib/astarte_rpc/protocol/proto/realm_management/get_datastream_maximum_storage_retention_reply.proto";
 
 
 message Reply {
@@ -49,5 +50,6 @@ message Reply {
         GetTriggerPoliciesListReply get_trigger_policies_list_reply = 12;
         GetTriggerPolicySourceReply get_trigger_policy_source_reply = 13;
         GetDeviceRegistrationLimitReply get_device_registration_limit_reply = 14;
+        GetDatastreamMaximumStorageRetentionReply get_datastream_maximum_storage_retention_reply = 15;
     }
 }

--- a/test/astarte/rpc/protocol/housekeeping_test.exs
+++ b/test/astarte/rpc/protocol/housekeeping_test.exs
@@ -103,7 +103,8 @@ defmodule Astarte.RPC.Protocol.HousekeepingTest do
              jwt_public_key_pem: "",
              replication_class: :SIMPLE_STRATEGY,
              replication_factor: 0,
-             device_registration_limit: nil
+             device_registration_limit: nil,
+             datastream_maximum_storage_retention: 0
            } = Astarte.RPC.Protocol.Housekeeping.GetRealmReply.decode(encoded)
   end
 
@@ -150,6 +151,47 @@ defmodule Astarte.RPC.Protocol.HousekeepingTest do
       assert %UpdateRealm{
                realm: "testRealm",
                device_registration_limit: {:remove_limit, %RemoveLimit{}}
+             } = UpdateRealm.decode(encoded)
+    end
+
+    test "is correctly serialized when datastream_maximum_storage_retention is set" do
+      update_realm = %UpdateRealm{
+        realm: "testRealm",
+        datastream_maximum_storage_retention: 1
+      }
+
+      encoded = UpdateRealm.encode(update_realm)
+
+      assert %UpdateRealm{
+               realm: "testRealm",
+               datastream_maximum_storage_retention: 1
+             } = UpdateRealm.decode(encoded)
+    end
+
+    test "is correctly serialized when datastream_maximum_storage_retention is missing" do
+      update_realm = %UpdateRealm{
+        realm: "testRealm"
+      }
+
+      encoded = UpdateRealm.encode(update_realm)
+
+      assert %UpdateRealm{
+               realm: "testRealm",
+               datastream_maximum_storage_retention: nil
+             } = UpdateRealm.decode(encoded)
+    end
+
+    test "is correctly serialized when datastream_maximum_storage_retention is removed (set to 0 value)" do
+      update_realm = %UpdateRealm{
+        realm: "testRealm",
+        datastream_maximum_storage_retention: 0
+      }
+
+      encoded = UpdateRealm.encode(update_realm)
+
+      assert %UpdateRealm{
+               realm: "testRealm",
+               datastream_maximum_storage_retention: 0
              } = UpdateRealm.decode(encoded)
     end
   end


### PR DESCRIPTION
- Housekeeping RPC: Add a filed to realm creation, update and retrieval RPC to specify the maximum TTL for datastreams
- Realm Management RPC: Allow to query the Realm maximum TTL for datastreams